### PR TITLE
Handle unset comparison values

### DIFF
--- a/lib/comparison/index.js
+++ b/lib/comparison/index.js
@@ -39,14 +39,14 @@ exports.nmatches = function nmatches(a, b) {
  * String contains
  */
 exports.contains = function contains(a, b) {
-  return !!~a.indexOf(b);
+  return 'string' === typeof a && !!~a.indexOf(b);
 };
 
 /**
  * String *not* contains
  */
 exports.ncontains = function ncontains(a, b) {
-  return !~a.indexOf(b);
+  return 'string' !== typeof a || !~a.indexOf(b);
 };
 
 /**
@@ -151,7 +151,7 @@ exports.nweight = function nweight(a, b) {
  * Use software version logic, compare a to b and check for equality
  */
 exports.eqVersion = function eqVersion(a, b) {
-  return !versionCompare(a, b);
+  return versionCompare(a, b) === 0;
 };
 
 /**

--- a/test/comparison.test.js
+++ b/test/comparison.test.js
@@ -16,11 +16,17 @@ describe('Comparison test', function() {
     it('should compare equals to be false correctly', function() {
       comparators.eq('one string', 'two string').should.equal(false);
     });
+    it('should handle empty values when processing equals', function() {
+      comparators.eq(undefined, 1).should.equal(false);
+    });
     it('should compare not equals correctly, number same type', function() {
       comparators.neq(1, 2).should.equal(true);
     });
     it('should compare not equals to be false correctly', function() {
       comparators.neq('1', 1).should.equal(false);
+    });
+    it('should handle empty values when processing not equals', function() {
+      comparators.neq(undefined, 1).should.equal(true);
     });
   });
 
@@ -34,11 +40,17 @@ describe('Comparison test', function() {
     it('should compare identity false correctly, types', function() {
       comparators.is(1, '1').should.equal(false);
     });
+    it('should handle empty values when processing identity', function() {
+      comparators.is(undefined, 1).should.equal(false);
+    });
     it('should compare negative identity true correctly', function() {
       comparators.not(1, 2).should.equal(true);
     });
     it('should compare negative identity false correctly, values', function() {
       comparators.not(1, 1).should.equal(false);
+    });
+    it('should handle empty values when processing negative identity', function() {
+      comparators.not(undefined, 1).should.equal(true);
     });
   });
 
@@ -49,11 +61,17 @@ describe('Comparison test', function() {
     it('should compare gt false correctly', function() {
       comparators.gt(0, 1).should.equal(false);
     });
+    it('should handle empty values when processing gt', function() {
+      comparators.gt(undefined, 1).should.equal(false);
+    });
     it('should compare gte true correctly', function() {
       comparators.gte(1, 0).should.equal(true);
     });
     it('should compare gte false correctly', function() {
       comparators.gte(0, 1).should.equal(false);
+    });
+    it('should handle empty values when processing gte', function() {
+      comparators.gte(undefined, 1).should.equal(false);
     });
     it('should compare lt true correctly', function() {
       comparators.lt(0, 1).should.equal(true);
@@ -61,11 +79,17 @@ describe('Comparison test', function() {
     it('should compare lt false correctly', function() {
       comparators.lt(1, 0).should.equal(false);
     });
+    it('should handle empty values when processing lt', function() {
+      comparators.lt(undefined, 1).should.equal(false);
+    });
     it('should compare lte true correctly', function() {
       comparators.lte(0, 1).should.equal(true);
     });
     it('should compare lte false correctly', function() {
       comparators.lte(1, 0).should.equal(false);
+    });
+    it('should handle empty values when processing lte', function() {
+      comparators.lte(undefined, 1).should.equal(false);
     });
   });
 
@@ -76,11 +100,17 @@ describe('Comparison test', function() {
     it('should compare range false correctly', function() {
       comparators.inRange(5, [0, 4]).should.equal(false);
     });
+    it('should handle empty values when processing range', function() {
+      comparators.inRange(undefined, [0, 4]).should.equal(false);
+    });
     it('should compare neg range true correctly', function() {
       comparators.ninRange(3, [4, 6]).should.equal(true);
     });
     it('should compare neg range false correctly', function() {
       comparators.ninRange(3, [0, 4]).should.equal(false);
+    });
+    it('should handle empty values when processing neg range', function() {
+      comparators.ninRange(undefined, [0, 4]).should.equal(false);
     });
   });
 
@@ -100,11 +130,17 @@ describe('Comparison test', function() {
     it('should compare match false correctly', function() {
       comparators.matches('beh', /merf/).should.equal(false);
     });
+    it('should handle empty values when processing match', function() {
+      comparators.matches(undefined, /^meh$/).should.equal(false);
+    });
     it('should compare neg match true correctly', function() {
       comparators.nmatches('meh', /merf/).should.equal(true);
     });
     it('should compare neg match false correctly', function() {
       comparators.nmatches('beh', /^beh$/).should.equal(false);
+    });
+    it('should handle empty values when processing neg match', function() {
+      comparators.nmatches(undefined, /^meh$/).should.equal(true);
     });
   });
 
@@ -115,11 +151,17 @@ describe('Comparison test', function() {
     it('should compare contains false correctly', function() {
       comparators.contains('beh', 'meh').should.equal(false);
     });
+    it('should handle empty values when processing contains', function() {
+      comparators.contains(undefined, 'meh').should.equal(false);
+    });
     it('should compare neg contains true correctly', function() {
       comparators.ncontains('meh', 'b').should.equal(true);
     });
     it('should compare neg contains false correctly', function() {
       comparators.ncontains('beh', 'eh').should.equal(false);
+    });
+    it('should handle empty values when processing neg contains', function() {
+      comparators.ncontains(undefined, 'meh').should.equal(true);
     });
   });
 
@@ -130,11 +172,17 @@ describe('Comparison test', function() {
     it('should compare divisibleBy false correctly', function() {
       comparators.divisibleBy(9, 4).should.equal(false);
     });
+    it('should handle empty values when processing divisibleBy', function() {
+      comparators.divisibleBy(undefined, 3).should.equal(false);
+    });
     it('should compare ndivisbleBy true correctly', function() {
       comparators.ndivisibleBy(9, 4).should.equal(true);
     });
     it('should compare ndivisibleBy false correctly', function() {
       comparators.ndivisibleBy(9, 3).should.equal(false);
+    });
+    it('should handle empty values when processing ndivisibleBy', function() {
+      comparators.ndivisibleBy(undefined, 3).should.equal(true);
     });
   });
 
@@ -160,11 +208,17 @@ describe('Comparison test', function() {
     it('should compare equal versions false correctly', function() {
       comparators.eqVersion('1.11.0', '1.11.1').should.equal(false);
     });
+    it('should handle empty values when processing equal versions', function() {
+      comparators.eqVersion(undefined, '1.11.0').should.equal(false);
+    });
     it('should compare gt versions true correctly', function() {
       comparators.gtVersion('1.2.0', '1.11.0').should.equal(true);
     });
     it('should compare gt versions false correctly', function() {
       comparators.gtVersion('1.11.0', '1.2.0').should.equal(false);
+    });
+    it('should handle empty values when processing gt versions', function() {
+      comparators.gtVersion(undefined, '1.11.0').should.equal(false);
     });
     it('should compare gte versions true correctly', function() {
       comparators.gteVersion('1.2.0', '1.11.0').should.equal(true);
@@ -173,11 +227,17 @@ describe('Comparison test', function() {
     it('should compare gte versions false correctly', function() {
       comparators.gteVersion('1.11.0', '1.2.0').should.equal(false);
     });
+    it('should handle empty values when processing gt versions', function() {
+      comparators.gteVersion(undefined, '1.11.0').should.equal(false);
+    });
     it('should compare lt versions true correctly', function() {
       comparators.ltVersion('1.11.0', '1.2.0').should.equal(true);
     });
     it('should compare lt versions false correctly', function() {
       comparators.ltVersion('1.2.0', '1.11.0').should.equal(false);
+    });
+    it('should handle empty values when processing gt versions', function() {
+      comparators.ltVersion(undefined, '1.11.0').should.equal(false);
     });
     it('should compare lte versions true correctly', function() {
       comparators.lteVersion('1.11.0', '1.2.0').should.equal(true);
@@ -185,6 +245,9 @@ describe('Comparison test', function() {
     });
     it('should compare lte versions false correctly', function() {
       comparators.lteVersion('1.2.0', '1.11.0').should.equal(false);
+    });
+    it('should handle empty values when processing gt versions', function() {
+      comparators.lteVersion(undefined, '1.11.0').should.equal(false);
     });
   });
 });


### PR DESCRIPTION
This prevents any errors in the case a comparison value is unset, or is not a string when doing `contains` or `ncontains`. It also adds strict checking when comparing versions so an unset comparison value passed to `eqVersion` will always result in false.